### PR TITLE
refactor: migrate to redis-ipc v0.7.0 and fix GPS race condition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-BIN := modem-service
+BINARY_NAME := modem-service
 GIT_REV := $(shell git describe --tags --always 2>/dev/null)
 ifdef GIT_REV
 LDFLAGS := -X main.version=$(GIT_REV)
@@ -8,25 +8,42 @@ endif
 BUILDFLAGS := -tags netgo,osusergo
 MAIN := ./cmd/modem-service
 
-.PHONY: build amd64 arm build-arm clean
+.PHONY: build build-host build-amd64 amd64 arm build-arm clean lint test fmt deps
 
 dev: build
 build:
-	go build -ldflags "$(LDFLAGS)" -o ${BIN} ${MAIN}
+	go build -ldflags "$(LDFLAGS)" -o ${BINARY_NAME} ${MAIN}
+
+build-host:
+	go build -ldflags "$(LDFLAGS)" -o ${BINARY_NAME} ${MAIN}
 
 amd64:
-	GOOS=linux GOARCH=amd64 go build -ldflags "$(LDFLAGS)" $(BUILDFLAGS) -o ${BIN}-amd64 ${MAIN}
+	GOOS=linux GOARCH=amd64 go build -ldflags "$(LDFLAGS)" $(BUILDFLAGS) -o ${BINARY_NAME}-amd64 ${MAIN}
+
+build-amd64: amd64
 
 arm:
-	GOOS=linux GOARCH=arm GOARM=7 go build -ldflags "$(LDFLAGS)" $(BUILDFLAGS) -o ${BIN}-arm ${MAIN}
+	GOOS=linux GOARCH=arm GOARM=7 go build -ldflags "$(LDFLAGS)" $(BUILDFLAGS) -o ${BINARY_NAME}-arm ${MAIN}
 
 build-arm: arm
 
 dist:
-	GOOS=linux GOARCH=arm GOARM=7 CGO_ENABLED=0 go build -ldflags "$(LDFLAGS) -s -w" $(BUILDFLAGS) -o ${BIN}-arm-dist ${MAIN}
+	GOOS=linux GOARCH=arm GOARM=7 CGO_ENABLED=0 go build -ldflags "$(LDFLAGS) -s -w" $(BUILDFLAGS) -o ${BINARY_NAME}-arm-dist ${MAIN}
 
 arm-debug:
-	GOOS=linux GOARCH=arm GOARM=7 CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" -gcflags="all=-N -l" $(BUILDFLAGS) -o ${BIN}-arm-debug ${MAIN}
+	GOOS=linux GOARCH=arm GOARM=7 CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" -gcflags="all=-N -l" $(BUILDFLAGS) -o ${BINARY_NAME}-arm-debug ${MAIN}
 
 clean:
-	rm -f ${BIN} ${BIN}-amd64 ${BIN}-arm ${BIN}-arm-dist ${BIN}-arm-debug
+	rm -f ${BINARY_NAME} ${BINARY_NAME}-amd64 ${BINARY_NAME}-arm ${BINARY_NAME}-arm-dist ${BINARY_NAME}-arm-debug
+
+lint:
+	golangci-lint run
+
+test:
+	go test -v ./...
+
+fmt:
+	go fmt ./...
+
+deps:
+	go mod download && go mod tidy

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module modem-service
 go 1.22.2
 
 require (
-	github.com/redis/go-redis/v9 v9.7.0
+	github.com/librescoot/redis-ipc v0.7.0
 	github.com/rescoot/go-mmcli v0.5.0
 	github.com/stratoberry/go-gpsd v1.3.0
 )
@@ -11,4 +11,5 @@ require (
 require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+	github.com/redis/go-redis/v9 v9.7.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,14 @@ github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
+github.com/librescoot/redis-ipc v0.4.0 h1:QDj7b3305/Cu973+S4yQdkx/0dAXoCi83ViCsmy63WI=
+github.com/librescoot/redis-ipc v0.4.0/go.mod h1:S6CD2Na6Adn4Fs3bsMoPWc3dYi80jGx/lnaTDLjmC+g=
+github.com/librescoot/redis-ipc v0.5.0 h1:mCuTOXE6E+bFav4Bka8zS4h1hDaYzEtFsH+XtT25E28=
+github.com/librescoot/redis-ipc v0.5.0/go.mod h1:S6CD2Na6Adn4Fs3bsMoPWc3dYi80jGx/lnaTDLjmC+g=
+github.com/librescoot/redis-ipc v0.6.0 h1:f6MbGTljmrykL4+sfTJBqBUdiGBmMlB06TwqkJmc6i4=
+github.com/librescoot/redis-ipc v0.6.0/go.mod h1:S6CD2Na6Adn4Fs3bsMoPWc3dYi80jGx/lnaTDLjmC+g=
+github.com/librescoot/redis-ipc v0.7.0 h1:A7Re6Sce4dily1micCEn48bFknJuaMkjRttgwbtOZBE=
+github.com/librescoot/redis-ipc v0.7.0/go.mod h1:S6CD2Na6Adn4Fs3bsMoPWc3dYi80jGx/lnaTDLjmC+g=
 github.com/redis/go-redis/v9 v9.7.0 h1:HhLSs+B6O021gwzl+locl0zEDnyNkxMtf/Z3NNBMa9E=
 github.com/redis/go-redis/v9 v9.7.0/go.mod h1:f6zhXITC7JUJIlPEiBOTXxJgPLdZcA93GewI7inzyWw=
 github.com/rescoot/go-mmcli v0.5.0 h1:IdsGaTQ8JJF009mF1ib49LeU2307XsKaXUHM8ATQ6U8=

--- a/internal/redis/redis_test.go
+++ b/internal/redis/redis_test.go
@@ -1,0 +1,441 @@
+package redis
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"testing"
+	"time"
+)
+
+// getTestRedisURL returns the Redis URL for testing
+func getTestRedisURL() string {
+	url := os.Getenv("REDIS_URL")
+	if url == "" {
+		url = "redis://localhost:6379"
+	}
+	return url
+}
+
+// setupTestClient creates a test client and cleans up test data
+func setupTestClient(t *testing.T) (*Client, func()) {
+	t.Helper()
+
+	logger := log.New(os.Stdout, "test: ", log.LstdFlags)
+	client, err := New(getTestRedisURL(), logger)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	// Check if Redis is available
+	if err := client.Ping(); err != nil {
+		t.Skipf("Redis not available: %v", err)
+	}
+
+	cleanup := func() {
+		// Clean up test data
+		client.client.Hash("internet").Clear()
+		client.client.Hash("modem").Clear()
+		client.client.Hash("gps").Clear()
+		client.Close()
+	}
+
+	return client, cleanup
+}
+
+func TestNew(t *testing.T) {
+	logger := log.New(os.Stdout, "test: ", log.LstdFlags)
+
+	tests := []struct {
+		name      string
+		redisURL  string
+		wantErr   bool
+		wantHost  string
+		wantPort  int
+	}{
+		{
+			name:     "valid URL with port",
+			redisURL: "redis://localhost:6379",
+			wantErr:  false,
+		},
+		{
+			name:     "valid URL without port",
+			redisURL: "redis://localhost",
+			wantErr:  false,
+		},
+		{
+			name:     "empty URL defaults to localhost:6379",
+			redisURL: "",
+			wantErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, err := New(tt.redisURL, logger)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("New() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && client != nil {
+				client.Close()
+			}
+		})
+	}
+}
+
+func TestNewWithVariousURLFormats(t *testing.T) {
+	logger := log.New(os.Stdout, "test: ", log.LstdFlags)
+
+	tests := []struct {
+		name     string
+		url      string
+		wantErr  bool
+		skipTest bool
+	}{
+		{
+			name:    "full URL with port",
+			url:     "redis://localhost:6379",
+			wantErr: false,
+		},
+		{
+			name:    "URL without scheme",
+			url:     "localhost:6379",
+			wantErr: false,
+		},
+		{
+			name:    "URL without port",
+			url:     "localhost",
+			wantErr: false,
+		},
+		{
+			name:    "empty URL defaults to localhost:6379",
+			url:     "",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.skipTest {
+				t.Skip("Skipping test that requires Redis")
+			}
+
+			client, err := New(tt.url, logger)
+			if (err != nil) != tt.wantErr {
+				// Connection errors are acceptable if Redis isn't running
+				if err != nil && !tt.wantErr {
+					t.Logf("New() error = %v (Redis may not be available)", err)
+					return
+				}
+				t.Errorf("New() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && client != nil {
+				client.Close()
+			}
+		})
+	}
+}
+
+func TestPublishInternetState(t *testing.T) {
+	client, cleanup := setupTestClient(t)
+	defer cleanup()
+
+	tests := []struct {
+		name    string
+		key     string
+		field   string
+		value   string
+		wantErr bool
+	}{
+		{
+			name:    "publish status",
+			key:     "internet",
+			field:   "status",
+			value:   "connected",
+			wantErr: false,
+		},
+		{
+			name:    "publish modem-state",
+			key:     "internet",
+			field:   "modem-state",
+			value:   "registered",
+			wantErr: false,
+		},
+		{
+			name:    "publish ip-address",
+			key:     "internet",
+			field:   "ip-address",
+			value:   "10.0.0.1",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := client.PublishInternetState(tt.key, tt.field, tt.value)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("PublishInternetState() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			// Verify the value was set
+			if !tt.wantErr {
+				val, err := client.client.Hash("internet").Get(tt.field)
+				if err != nil {
+					t.Errorf("Failed to get field %s: %v", tt.field, err)
+				}
+				if val != tt.value {
+					t.Errorf("Field %s = %v, want %v", tt.field, val, tt.value)
+				}
+			}
+		})
+	}
+}
+
+func TestPublishInternetStateChangeDetection(t *testing.T) {
+	client, cleanup := setupTestClient(t)
+	defer cleanup()
+
+	// First publish should succeed
+	err := client.PublishInternetState("internet", "status", "connected")
+	if err != nil {
+		t.Fatalf("First publish failed: %v", err)
+	}
+
+	// Second publish with same value should not trigger a change
+	// (SetIfChanged will still return success, but won't publish)
+	err = client.PublishInternetState("internet", "status", "connected")
+	if err != nil {
+		t.Fatalf("Second publish failed: %v", err)
+	}
+
+	// Third publish with different value should trigger a change
+	err = client.PublishInternetState("internet", "status", "disconnected")
+	if err != nil {
+		t.Fatalf("Third publish failed: %v", err)
+	}
+
+	// Verify final value
+	val, err := client.client.Hash("internet").Get("status")
+	if err != nil {
+		t.Fatalf("Failed to get status: %v", err)
+	}
+	if val != "disconnected" {
+		t.Errorf("status = %v, want disconnected", val)
+	}
+}
+
+func TestPublishModemState(t *testing.T) {
+	client, cleanup := setupTestClient(t)
+	defer cleanup()
+
+	tests := []struct {
+		name    string
+		field   string
+		value   string
+		wantErr bool
+	}{
+		{
+			name:    "publish power-state",
+			field:   "power-state",
+			value:   "on",
+			wantErr: false,
+		},
+		{
+			name:    "publish sim-state",
+			field:   "sim-state",
+			value:   "registered",
+			wantErr: false,
+		},
+		{
+			name:    "publish operator-name",
+			field:   "operator-name",
+			value:   "TestCarrier",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := client.PublishModemState(tt.field, tt.value)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("PublishModemState() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			// Verify the value was set
+			if !tt.wantErr {
+				val, err := client.client.Hash("modem").Get(tt.field)
+				if err != nil {
+					t.Errorf("Failed to get field %s: %v", tt.field, err)
+				}
+				if val != tt.value {
+					t.Errorf("Field %s = %v, want %v", tt.field, val, tt.value)
+				}
+			}
+		})
+	}
+}
+
+func TestPublishLocationState(t *testing.T) {
+	client, cleanup := setupTestClient(t)
+	defer cleanup()
+
+	tests := []struct {
+		name            string
+		data            map[string]interface{}
+		publishRecovery bool
+		wantErr         bool
+		description     string
+	}{
+		{
+			name: "regular GPS update (no publish)",
+			data: map[string]interface{}{
+				"latitude":  "45.123456",
+				"longitude": "-122.654321",
+				"altitude":  "100.5",
+				"speed":     "25.0",
+				"course":    "180.0",
+				"timestamp": time.Now().Format(time.RFC3339),
+			},
+			publishRecovery: false,
+			wantErr:         false,
+			description:     "Regular update - sets hash without publishing",
+		},
+		{
+			name: "GPS status without fix (no publish)",
+			data: map[string]interface{}{
+				"fix":       "no-fix",
+				"quality":   "0.0",
+				"active":    false,
+				"connected": true,
+			},
+			publishRecovery: false,
+			wantErr:         false,
+			description:     "Status update - sets hash without publishing",
+		},
+		{
+			name: "GPS recovery (publish timestamp)",
+			data: map[string]interface{}{
+				"latitude":  "45.123456",
+				"longitude": "-122.654321",
+				"timestamp": time.Now().Format(time.RFC3339),
+			},
+			publishRecovery: true,
+			wantErr:         false,
+			description:     "Recovery event - publishes single 'timestamp' notification",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Logf("Testing: %s", tt.description)
+
+			err := client.PublishLocationState(tt.data, tt.publishRecovery)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("PublishLocationState() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			// Verify the data was set (check a few fields)
+			if !tt.wantErr {
+				all, err := client.client.Hash("gps").GetAll()
+				if err != nil {
+					t.Fatalf("Failed to get all GPS data: %v", err)
+				}
+
+				// Check that updated timestamp was added
+				if _, ok := all["updated"]; !ok {
+					t.Error("updated timestamp not found in GPS data")
+				}
+
+				// Verify some fields from input data
+				for k, v := range tt.data {
+					val, ok := all[k]
+					if !ok {
+						t.Errorf("Field %s not found in GPS data", k)
+						continue
+					}
+					expectedStr := fmt.Sprintf("%v", v)
+					if val != expectedStr {
+						t.Errorf("Field %s = %v, want %v", k, val, expectedStr)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestPing(t *testing.T) {
+	client, cleanup := setupTestClient(t)
+	defer cleanup()
+
+	err := client.Ping()
+	if err != nil {
+		t.Errorf("Ping() error = %v", err)
+	}
+}
+
+func TestClose(t *testing.T) {
+	logger := log.New(os.Stdout, "test: ", log.LstdFlags)
+	client, err := New(getTestRedisURL(), logger)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	err = client.Close()
+	if err != nil {
+		t.Errorf("Close() error = %v", err)
+	}
+}
+
+// TestConcurrentPublishing tests that concurrent publishes don't cause issues
+func TestConcurrentPublishing(t *testing.T) {
+	client, cleanup := setupTestClient(t)
+	defer cleanup()
+
+	done := make(chan bool)
+
+	// Publish internet state concurrently
+	go func() {
+		for i := 0; i < 10; i++ {
+			client.PublishInternetState("internet", "test-field", fmt.Sprintf("value-%d", i))
+			time.Sleep(10 * time.Millisecond)
+		}
+		done <- true
+	}()
+
+	// Publish modem state concurrently
+	go func() {
+		for i := 0; i < 10; i++ {
+			client.PublishModemState("test-field", fmt.Sprintf("modem-%d", i))
+			time.Sleep(10 * time.Millisecond)
+		}
+		done <- true
+	}()
+
+	// Publish GPS state concurrently
+	go func() {
+		for i := 0; i < 10; i++ {
+			data := map[string]interface{}{
+				"latitude":  fmt.Sprintf("45.%d", i),
+				"longitude": fmt.Sprintf("-122.%d", i),
+			}
+			client.PublishLocationState(data, false)
+			time.Sleep(10 * time.Millisecond)
+		}
+		done <- true
+	}()
+
+	// Wait for all goroutines
+	<-done
+	<-done
+	<-done
+
+	// Verify we can still read data
+	val, err := client.client.Hash("internet").Get("test-field")
+	if err != nil {
+		t.Logf("Internet test-field not found (expected after concurrent updates): %v", err)
+	} else {
+		t.Logf("Final internet test-field value: %s", val)
+	}
+}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -52,7 +52,7 @@ func New(cfg *config.Config, logger *log.Logger, version string) (*Service, erro
 }
 
 func (s *Service) Run(ctx context.Context) error {
-	if err := s.Redis.Ping(ctx); err != nil {
+	if err := s.Redis.Ping(); err != nil {
 		return fmt.Errorf("redis connection failed: %v", err)
 	}
 
@@ -261,7 +261,7 @@ func (s *Service) attemptRecovery() error {
 }
 
 func (s *Service) publishHealthState(ctx context.Context) error {
-	return s.Redis.PublishInternetState(ctx, "internet", "modem-health", s.Health.State)
+	return s.Redis.PublishInternetState("internet", "modem-health", s.Health.State)
 }
 
 // handleGPSFailure attempts GPS-specific recovery before escalating to modem recovery
@@ -352,7 +352,7 @@ func (s *Service) publishModemState(ctx context.Context, currentState *modem.Sta
 	// NOTE: LastState.Status here refers to the overall internet connectivity, not the raw modem status.
 	if s.LastState.Status != internetStatus {
 		s.Logger.Printf("internet status: %s", internetStatus)
-		if err := s.Redis.PublishInternetState(ctx, "internet", "status", internetStatus); err != nil {
+		if err := s.Redis.PublishInternetState("internet", "status", internetStatus); err != nil {
 			return err
 		}
 		s.LastState.Status = internetStatus // Store the published internet status
@@ -361,7 +361,7 @@ func (s *Service) publishModemState(ctx context.Context, currentState *modem.Sta
 	// Publish the raw modem state (1:1 copy of currentState.Status)
 	if s.LastState.LastRawModemStatus != currentState.Status {
 		s.Logger.Printf("internet modem-state: %s", currentState.Status)
-		if err := s.Redis.PublishInternetState(ctx, "internet", "modem-state", currentState.Status); err != nil {
+		if err := s.Redis.PublishInternetState("internet", "modem-state", currentState.Status); err != nil {
 			// Log error but don't necessarily fail the whole publish operation for this specific field
 			s.Logger.Printf("Failed to publish internet modem-state: %v", err)
 		}
@@ -371,7 +371,7 @@ func (s *Service) publishModemState(ctx context.Context, currentState *modem.Sta
 	// Publish modem's reported IP address (might be present even if ping fails)
 	if s.LastState.IfIPAddr != currentState.IfIPAddr {
 		s.Logger.Printf("internet ip-address: %s", currentState.IfIPAddr)
-		if err := s.Redis.PublishInternetState(ctx, "internet", "ip-address", currentState.IfIPAddr); err != nil {
+		if err := s.Redis.PublishInternetState("internet", "ip-address", currentState.IfIPAddr); err != nil {
 			return err
 		}
 		s.LastState.IfIPAddr = currentState.IfIPAddr
@@ -379,7 +379,7 @@ func (s *Service) publishModemState(ctx context.Context, currentState *modem.Sta
 
 	if s.LastState.AccessTech != currentState.AccessTech {
 		s.Logger.Printf("internet access-tech: %s", currentState.AccessTech)
-		if err := s.Redis.PublishInternetState(ctx, "internet", "access-tech", currentState.AccessTech); err != nil {
+		if err := s.Redis.PublishInternetState("internet", "access-tech", currentState.AccessTech); err != nil {
 			return err
 		}
 		s.LastState.AccessTech = currentState.AccessTech
@@ -387,7 +387,7 @@ func (s *Service) publishModemState(ctx context.Context, currentState *modem.Sta
 
 	if s.LastState.SignalQuality != currentState.SignalQuality {
 		s.Logger.Printf("internet signal-quality: %d", currentState.SignalQuality)
-		if err := s.Redis.PublishInternetState(ctx, "internet", "signal-quality", fmt.Sprintf("%d", currentState.SignalQuality)); err != nil {
+		if err := s.Redis.PublishInternetState("internet", "signal-quality", fmt.Sprintf("%d", currentState.SignalQuality)); err != nil {
 			return err
 		}
 		s.LastState.SignalQuality = currentState.SignalQuality
@@ -395,7 +395,7 @@ func (s *Service) publishModemState(ctx context.Context, currentState *modem.Sta
 
 	if s.LastState.PowerState != currentState.PowerState {
 		s.Logger.Printf("modem power-state: %s", currentState.PowerState)
-		if err := s.Redis.PublishModemState(ctx, "power-state", currentState.PowerState); err != nil {
+		if err := s.Redis.PublishModemState("power-state", currentState.PowerState); err != nil {
 			return err
 		}
 		s.LastState.PowerState = currentState.PowerState
@@ -403,7 +403,7 @@ func (s *Service) publishModemState(ctx context.Context, currentState *modem.Sta
 
 	if s.LastState.SIMState != currentState.SIMState {
 		s.Logger.Printf("modem sim-state: %s", currentState.SIMState)
-		if err := s.Redis.PublishModemState(ctx, "sim-state", currentState.SIMState); err != nil {
+		if err := s.Redis.PublishModemState("sim-state", currentState.SIMState); err != nil {
 			return err
 		}
 		s.LastState.SIMState = currentState.SIMState
@@ -411,7 +411,7 @@ func (s *Service) publishModemState(ctx context.Context, currentState *modem.Sta
 
 	if s.LastState.SIMLockStatus != currentState.SIMLockStatus {
 		s.Logger.Printf("modem sim-lock: %s", currentState.SIMLockStatus)
-		if err := s.Redis.PublishModemState(ctx, "sim-lock", currentState.SIMLockStatus); err != nil {
+		if err := s.Redis.PublishModemState("sim-lock", currentState.SIMLockStatus); err != nil {
 			return err
 		}
 		s.LastState.SIMLockStatus = currentState.SIMLockStatus
@@ -419,7 +419,7 @@ func (s *Service) publishModemState(ctx context.Context, currentState *modem.Sta
 
 	if s.LastState.OperatorName != currentState.OperatorName {
 		s.Logger.Printf("operator name: %s", currentState.OperatorName)
-		if err := s.Redis.PublishModemState(ctx, "operator-name", currentState.OperatorName); err != nil {
+		if err := s.Redis.PublishModemState("operator-name", currentState.OperatorName); err != nil {
 			return err
 		}
 		s.LastState.OperatorName = currentState.OperatorName
@@ -427,7 +427,7 @@ func (s *Service) publishModemState(ctx context.Context, currentState *modem.Sta
 
 	if s.LastState.OperatorCode != currentState.OperatorCode {
 		s.Logger.Printf("operator code: %s", currentState.OperatorCode)
-		if err := s.Redis.PublishModemState(ctx, "operator-code", currentState.OperatorCode); err != nil {
+		if err := s.Redis.PublishModemState("operator-code", currentState.OperatorCode); err != nil {
 			return err
 		}
 		s.LastState.OperatorCode = currentState.OperatorCode
@@ -435,7 +435,7 @@ func (s *Service) publishModemState(ctx context.Context, currentState *modem.Sta
 
 	if s.LastState.IsRoaming != currentState.IsRoaming {
 		s.Logger.Printf("roaming: %t", currentState.IsRoaming)
-		if err := s.Redis.PublishModemState(ctx, "is-roaming", fmt.Sprintf("%t", currentState.IsRoaming)); err != nil {
+		if err := s.Redis.PublishModemState("is-roaming", fmt.Sprintf("%t", currentState.IsRoaming)); err != nil {
 			return err
 		}
 		s.LastState.IsRoaming = currentState.IsRoaming
@@ -443,7 +443,7 @@ func (s *Service) publishModemState(ctx context.Context, currentState *modem.Sta
 
 	if s.LastState.RegistrationFail != currentState.RegistrationFail {
 		s.Logger.Printf("registration-fail: %s", currentState.RegistrationFail)
-		if err := s.Redis.PublishModemState(ctx, "registration-fail", currentState.RegistrationFail); err != nil {
+		if err := s.Redis.PublishModemState("registration-fail", currentState.RegistrationFail); err != nil {
 			return err
 		}
 		s.LastState.RegistrationFail = currentState.RegistrationFail
@@ -451,7 +451,7 @@ func (s *Service) publishModemState(ctx context.Context, currentState *modem.Sta
 
 	if s.LastState.IMEI != currentState.IMEI {
 		s.Logger.Printf("modem IMEI: %s", currentState.IMEI)
-		if err := s.Redis.PublishInternetState(ctx, "internet", "sim-imei", currentState.IMEI); err != nil {
+		if err := s.Redis.PublishInternetState("internet", "sim-imei", currentState.IMEI); err != nil {
 			return err
 		}
 		s.LastState.IMEI = currentState.IMEI
@@ -459,7 +459,7 @@ func (s *Service) publishModemState(ctx context.Context, currentState *modem.Sta
 
 	if s.LastState.IMSI != currentState.IMSI {
 		s.Logger.Printf("SIM IMSI: %s", currentState.IMSI)
-		if err := s.Redis.PublishInternetState(ctx, "internet", "sim-imsi", currentState.IMSI); err != nil {
+		if err := s.Redis.PublishInternetState("internet", "sim-imsi", currentState.IMSI); err != nil {
 			return err
 		}
 		s.LastState.IMSI = currentState.IMSI
@@ -467,7 +467,7 @@ func (s *Service) publishModemState(ctx context.Context, currentState *modem.Sta
 
 	if s.LastState.ICCID != currentState.ICCID {
 		s.Logger.Printf("SIM ICCID: %s", currentState.ICCID)
-		if err := s.Redis.PublishInternetState(ctx, "internet", "sim-iccid", currentState.ICCID); err != nil {
+		if err := s.Redis.PublishInternetState("internet", "sim-iccid", currentState.ICCID); err != nil {
 			return err
 		}
 		s.LastState.ICCID = currentState.ICCID
@@ -476,7 +476,7 @@ func (s *Service) publishModemState(ctx context.Context, currentState *modem.Sta
 	// Publish the consolidated error state
 	if s.LastState.ErrorState != currentState.ErrorState {
 		s.Logger.Printf("modem error-state: %s", currentState.ErrorState)
-		if err := s.Redis.PublishModemState(ctx, "error-state", currentState.ErrorState); err != nil {
+		if err := s.Redis.PublishModemState("error-state", currentState.ErrorState); err != nil {
 			// Log error but don't necessarily fail the whole publish operation
 			s.Logger.Printf("Failed to publish modem error-state: %v", err)
 		}
@@ -500,7 +500,7 @@ func (s *Service) publishLocationState(ctx context.Context, loc location.Locatio
 		data[k] = v
 	}
 
-	return s.Redis.PublishLocationState(ctx, data, publishRecovery)
+	return s.Redis.PublishLocationState(data, publishRecovery)
 }
 
 func (s *Service) checkAndPublishModemStatus(ctx context.Context) error {
@@ -697,7 +697,7 @@ func (s *Service) monitorStatus(ctx context.Context) {
 						"active":    gpsStatus["active"],
 						"connected": gpsStatus["connected"],
 					}
-					if err := s.Redis.PublishLocationState(ctx, data, false); err != nil {
+					if err := s.Redis.PublishLocationState(data, false); err != nil {
 						s.Logger.Printf("Failed to publish GPS status: %v", err)
 					}
 				}


### PR DESCRIPTION
## Summary

This PR contains two improvements to modem-service:

### 1. Migrate to redis-ipc v0.7.0
Removes `context.Context` parameters from all redis-ipc method calls for cleaner API ergonomics.

- Update redis-ipc dependency from v0.6.0 to v0.7.0
- Remove `ctx` parameter from 4 Redis wrapper function signatures
- Remove `ctx` argument from 35 method call sites across service layer
- Remove unused `context` package imports
- Add comprehensive test coverage (441 lines) for all Redis operations

### 2. Fix GPS configuration race condition
Prevents concurrent GPS configuration attempts that caused duplicate "GPS not configured" messages in logs.

The race occurred when:
- GPS recovery calls Close() (sets Enabled=false, GpsdConn=nil)
- Then immediately calls EnableGPS() (sets Enabled=true, starts new goroutine)
- Old goroutine sees Enabled=true again and continues running
- Both goroutines see GpsdConn==nil and try to configure GPS concurrently

Fix uses double-checked locking with `configMutex`:
- Check GpsdConn==nil (fast path, no lock)
- Acquire mutex
- Re-check GpsdConn==nil (another goroutine might have already configured it)
- Configure GPS and connect to gpsd
- Release mutex

Also protects Close() and timeout reconnection logic with same mutex.

## Benefits

- Cleaner function signatures (one less parameter everywhere)
- Less boilerplate (no `ctx := context.Background()` needed)
- Same functionality (library manages context internally)
- Better test coverage
- Eliminates GPS configuration race condition

## Test Plan

- [x] All existing tests pass: `go test ./...`
- [x] Build succeeds: `go build ./...`
- [x] Added comprehensive unit tests for Redis package
- [x] Deployed and verified on deep-blue (version 0.3.4-3-g98ca285)
- [x] No GPS configuration race observed in logs after deployment

## Deployment

Already tested and running on deep-blue production vehicle.