### PR TITLE
feat(sim): unlock and lock-enable PIN-protected SIMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,10 +90,33 @@ The service maintains various Redis hashes:
 - `power-state` (on/off/low-power)
 - `sim-state` (active/locked/missing/unknown)
 - `sim-lock` (enabled/disabled/unknown)
+- `pin-action` outcome of the last SIM PIN reconcile cycle:
+  - `unconfigured` - no `cellular.sim-pin` setting
+  - `ok` - SIM is in the desired state
+  - `unlocked` - service just sent the PIN to unlock
+  - `lock-enabled` - service just enabled PIN lock with the configured PIN
+  - `wrong-pin` - last attempt was rejected; service will not retry until restart
+  - `low-retries-bail` - retries < 3, refusing to attempt to avoid PUK lock
+  - `puk-required` - SIM is in PUK state, manual recovery needed
+  - `error` - D-Bus call failed (see journal)
 - `operator-name` (current network operator name)
 - `operator-code` (current network operator code)
 - `is-roaming` (true/false)
 - `registration-fail` (reason if registration failed)
+
+When `cellular.sim-pin` is set in the `settings` Redis hash (typically via
+`/data/settings.toml` or the mobile app), modem-service will:
+
+- send the PIN to unlock the SIM if it's PIN-locked, or
+- enable PIN lock with the configured PIN if the SIM has the lock disabled.
+
+A wrong PIN attempt consumes one retry. To prevent the SIM from ever entering
+PUK state through the service, modem-service refuses to attempt a PIN unless
+`unlock-retries["sim-pin"]` is at the maximum (3) and the service has not
+already failed an attempt this run. To recover after a wrong-PIN configuration,
+fix the value, then unlock the SIM once manually (e.g.
+`mmcli -i 0 --send-pin=CORRECT`) — that restores the retry counter and
+modem-service will resume normally.
 
 #### `gps` hash
 

--- a/docs/superpowers/specs/2026-05-05-sim-pin-support-design.md
+++ b/docs/superpowers/specs/2026-05-05-sim-pin-support-design.md
@@ -1,0 +1,201 @@
+# SIM PIN unlock/enable support — design
+
+- Bean: librescoot-t0jf
+- Date: 2026-05-05
+- Status: design (pre-implementation)
+
+## Summary
+
+Add support for PIN-locked SIMs in modem-service. The user configures `cellular.sim-pin` via settings-service. modem-service reads it and either unlocks the SIM (when PIN-locked) or enables PIN lock (when PIN-disabled), gated by retry counts so the service can never brick a SIM by retrying a wrong PIN.
+
+## Goals
+
+- A PIN-locked SIM unlocks automatically on boot if `cellular.sim-pin` matches.
+- A SIM with PIN-lock disabled gets PIN-lock enabled if `cellular.sim-pin` is set and matches.
+- A wrong PIN consumes at most one retry per process lifetime, never drops `unlock-retries["sim-pin"]` below 2.
+- Lock state and last action outcome visible to other services via the existing `modem` Redis hash.
+- No PIN value ever logged to journal.
+
+## Non-goals
+
+- PUK handling. If the SIM enters PUK state, modem-service publishes `pin-action=puk-required` and stops; recovery is manual (`mmcli --send-puk`).
+- PIN2. The Deep-Blue test SIM runs in `unlock-required: sim-pin2` and is harmless for data; we never touch PIN2.
+- Multi-SIM. SIM7100E has one slot.
+- Changing the PIN. `cellular.sim-pin` is "the current PIN", not "the new PIN."
+- A scootui UI for entering the PIN. The setting flows through `/data/settings.toml` and the mobile app, both of which read settings regardless of the `user-visible` flag.
+
+## Trust boundary note
+
+`cellular.sim-pin` is plain text in `/data/settings.toml` and the `settings` Redis hash. settings-service has no "secret" type today — `wireguard.private-key` and similar credentials use the same path. This is acceptable for the threat model (the disk is encrypted at rest, the Redis socket is local-only). Worth flagging if/when a "secret" tier is added to settings-service.
+
+## Components
+
+### 1. settings-service schema
+
+One new entry in `settings-service/settings.schema.json`:
+
+```json
+"cellular.sim-pin": {
+  "type": "string",
+  "description": "PIN for SIM unlock and lock-enable (4–8 digits, empty = leave SIM as-is)",
+  "label": "SIM PIN",
+  "user-visible": false,
+  "service": "modem-service",
+  "default": "",
+  "example": "1234"
+}
+```
+
+`user-visible: false` because the DBC has no text-entry UI. settings.toml and the mobile app read all keys regardless.
+
+### 2. mm package additions (`internal/mm/client.go`)
+
+```go
+const SimInterface = "org.freedesktop.ModemManager1.Sim"
+
+// SendPin calls org.freedesktop.ModemManager1.Sim.SendPin(pin) on simPath.
+// Returns the raw D-Bus error on failure (caller maps to outcome).
+func (c *Client) SendPin(simPath dbus.ObjectPath, pin string) error
+
+// EnablePin calls org.freedesktop.ModemManager1.Sim.EnablePin(pin, enabled).
+func (c *Client) EnablePin(simPath dbus.ObjectPath, pin string, enabled bool) error
+
+// GetUnlockRetries reads modem.UnlockRetries (a{uu} → map[uint32]uint32),
+// keyed by MMLock* constants.
+func (c *Client) GetUnlockRetries(modemPath dbus.ObjectPath) (map[uint32]uint32, error)
+
+// GetEnabledFacilities reads modem.EnabledFacilityLocks (u, MM3gppFacility flags),
+// or modem.EnabledLocks if the modem exposes that. Used to detect whether sim-pin
+// lock is currently enabled or disabled on the SIM.
+func (c *Client) GetEnabledFacilities(modemPath dbus.ObjectPath) (uint32, error)
+```
+
+PIN string is never logged in mm. A short comment at each call site enforces it.
+
+### 3. modem.State extension
+
+`internal/modem/modem.go` — `State` already carries `SIMLockStatus`. Add:
+
+```go
+SIMPath              dbus.ObjectPath  // the SIM object path, used for SendPin/EnablePin
+SIMPinLockEnabled    bool             // sim-pin appears in EnabledFacilityLocks
+UnlockRetriesPin     uint32           // remaining attempts; 0 if unknown
+```
+
+These are populated alongside the existing SIM property reads.
+
+### 4. New package `internal/sim`
+
+One file, `internal/sim/manager.go`, ~150 lines.
+
+```go
+package sim
+
+type Outcome string
+
+const (
+    OutcomeUnconfigured  Outcome = "unconfigured"
+    OutcomeOK            Outcome = "ok"
+    OutcomeUnlocked      Outcome = "unlocked"
+    OutcomeLockEnabled   Outcome = "lock-enabled"
+    OutcomeWrongPin      Outcome = "wrong-pin"
+    OutcomeLowRetriesBail Outcome = "low-retries-bail"
+    OutcomePukRequired   Outcome = "puk-required"
+    OutcomeError         Outcome = "error"
+)
+
+type Manager struct {
+    mm     SimDBus    // narrow interface, mockable
+    logger *log.Logger
+    triedThisRun bool
+}
+
+type SimDBus interface {
+    SendPin(simPath dbus.ObjectPath, pin string) error
+    EnablePin(simPath dbus.ObjectPath, pin string, enabled bool) error
+}
+
+// Reconcile is called once per modem-status cycle after GetModemInfo.
+// It reads the current state and the configured PIN and decides whether to act.
+//
+// The caller is responsible for only invoking Reconcile when the modem is in a
+// state where SIM properties have been read (i.e. not during recovery).
+func (m *Manager) Reconcile(in Input) Outcome
+```
+
+`Input` carries `SIMPath`, `LockStatus`, `PinLockEnabled`, `UnlockRetriesPin`, `ConfiguredPIN`. Pure-data input keeps the manager testable without D-Bus.
+
+### 5. Decision matrix
+
+`Reconcile` implements this table:
+
+| Configured PIN | `unlock-required` | `enabled-locks` has `sim-pin`? | Action |
+|---|---|---|---|
+| empty | * | * | `unconfigured`, no-op |
+| set | `sim-pin` | (locked, can't read) | If `retries[pin] >= 3` and `!triedThisRun`: `SendPin`. On success → `unlocked`. On bad-pin error → `wrong-pin`, `triedThisRun=true`. On other error → `error`. If `retries[pin] < 3`: `low-retries-bail`. If `triedThisRun`: stay `wrong-pin`. |
+| set | `sim-pin2` | yes | `ok` (PIN already enabled, PIN2 harmless) |
+| set | `sim-pin2` | no | `ok` (we leave PIN2 alone; SIM is otherwise fine) |
+| set | `sim-puk` or `sim-puk2` | * | `puk-required`, no-op |
+| set | `none` | yes | `ok` |
+| set | `none` | no | If `retries[pin] >= 3` and `!triedThisRun`: `EnablePin(pin, true)`. On success → `lock-enabled`. On bad-pin error → `wrong-pin`, `triedThisRun=true`. Else same gating as the unlock row. |
+
+`triedThisRun`:
+- Flips to true only on a *failed* attempt that consumed a retry.
+- A successful action does *not* flip it — a follow-up settings change in the same run can try again.
+- Resets on process restart, but the retry-count gate still protects: once retries drop to 2, no automatic attempt happens until something brings it back to 3 (which only a successful unlock can do, performed manually via `mmcli --send-pin`).
+
+### 6. Wiring in `service/service.go`
+
+Inside `monitorStatus`, after `modemMgr.GetModemInfo` returns `currentState`:
+
+1. Read latest `cellular.sim-pin` from the cached settings (existing `HashWatcher` keeps it fresh).
+2. Build `sim.Input` from `currentState` + the configured PIN.
+3. Call `simMgr.Reconcile(input)`.
+4. Add `currentState.PinAction` to the change-detection block; publish to `modem.pin-action` when it differs from `LastState.PinAction`.
+
+The existing `HashWatcher.OnField("cellular.sim-pin", ...)` callback stores the value in a struct field guarded by `sync.Mutex`. The reconcile cycle reads that field. No tighter coupling than that.
+
+### 7. Redis output
+
+New field on the existing `modem` hash: `pin-action`, values from the `Outcome` enum above. Separate from `error-state` because `pin-action` is the result of an action attempt, not a steady-state error description. `error-state="sim-locked"` and `pin-action="wrong-pin"` are both useful and orthogonal.
+
+### 8. Logging
+
+- One INFO line per state transition: `pin-action: unconfigured -> unlocked` (no PIN value).
+- One WARN line on `wrong-pin`: includes remaining retries from the modem property.
+- One WARN line on `low-retries-bail`: explains why we won't try.
+- D-Bus errors logged at ERROR with the raw error string (which never contains the PIN — ModemManager error strings reference the operation, not arguments).
+
+### 9. Tests
+
+`internal/sim/manager_test.go` — table-driven coverage of every row in the decision matrix using a mock `SimDBus` that records the call and returns a configurable error. Test PIN values are obviously fake (`"0000"`).
+
+Two integration touch points are not unit-tested (covered manually on Deep Blue):
+
+- The actual D-Bus call to ModemManager — exercised by stopping `librescoot-modem`, locking the SIM via `mmcli --enable-pin --pin=...`, configuring `cellular.sim-pin`, and restarting the service.
+- The `HashWatcher` plumbing — already exercised by other settings in the service.
+
+## Failure modes and recovery
+
+| Situation | What happens |
+|---|---|
+| User configures wrong PIN | First boot: one attempt, retries 3→2, `pin-action=wrong-pin`. Subsequent boots: `low-retries-bail`. User edits settings, fixes PIN. Service still bails because retries=2. User manually unlocks once via `mmcli --send-pin=CORRECT` (resetting retries to 3 on success); next service cycle sees retries=3 and acts normally. |
+| User changes PIN on SIM via another device | Same as wrong-PIN flow above. |
+| modem-service restarts mid-day for unrelated reasons | `triedThisRun` resets but retries are still 3 if untouched. Service re-reads state, sees `unlock-required=none` and `sim-pin` enabled → `ok`. No-op. |
+| Modem hard-reset (existing recovery path) | After modem reappears, GetModemInfo populates fresh state; reconcile runs again. Same gating applies. |
+| SIM enters PUK state (3 wrong PINs from any source) | `pin-action=puk-required`. Service does nothing. Manual recovery required. |
+
+## File touch list
+
+- `settings-service/settings.schema.json` — add `cellular.sim-pin`
+- `modem-service/internal/mm/client.go` — add `SendPin`, `EnablePin`, `GetUnlockRetries`, `GetEnabledFacilities`, `SimInterface` const
+- `modem-service/internal/modem/modem.go` — extend `State`, populate new fields in `GetModemInfo`
+- `modem-service/internal/sim/manager.go` — new file
+- `modem-service/internal/sim/manager_test.go` — new file
+- `modem-service/internal/service/service.go` — wire `simMgr.Reconcile` into `monitorStatus`, add `pin-action` change detection, register a `HashWatcher` field for `cellular.sim-pin`
+- `modem-service/internal/redis/redis.go` — minor: ensure the existing `HashWatcher` plumbing covers the new field (likely no change, just a registration call from `service.go`)
+- `modem-service/README.md` — document `pin-action` field
+
+## Open questions
+
+None at design time. If implementation surfaces an MM idiom mismatch (e.g. the `EnabledFacilityLocks` property name varies across MM versions), the implementer falls back to parsing `mmcli --output-json` if needed and notes the deviation in the implementation plan.

--- a/internal/mm/client.go
+++ b/internal/mm/client.go
@@ -19,6 +19,13 @@ const (
 	Modem3gppInterface     = "org.freedesktop.ModemManager1.Modem.Modem3gpp"
 	ModemLocationInterface = "org.freedesktop.ModemManager1.Modem.Location"
 	ModemSimpleInterface   = "org.freedesktop.ModemManager1.Modem.Simple"
+	SimInterface           = "org.freedesktop.ModemManager1.Sim"
+
+	// MobileEquipment error names returned by ModemManager when SIM PIN
+	// operations fail. Used by IsWrongPinError and IsPukRequiredError.
+	ErrIncorrectPassword = "org.freedesktop.ModemManager1.Error.MobileEquipment.IncorrectPassword"
+	ErrSimPuk            = "org.freedesktop.ModemManager1.Error.MobileEquipment.SimPuk"
+	ErrSimPuk2           = "org.freedesktop.ModemManager1.Error.MobileEquipment.SimPuk2"
 
 	DBusPropertiesInterface = "org.freedesktop.DBus.Properties"
 	DBusObjectManager       = "org.freedesktop.DBus.ObjectManager"
@@ -139,6 +146,71 @@ func (c *Client) Enable(modemPath dbus.ObjectPath, enable bool) error {
 func (c *Client) Reset(modemPath dbus.ObjectPath) error {
 	call := c.CallMethod(modemPath, ModemInterface, "Reset")
 	return call.Err
+}
+
+// SendPin sends a PIN to unlock the SIM. The pin string is never logged.
+func (c *Client) SendPin(simPath dbus.ObjectPath, pin string) error {
+	obj := c.conn.Object(ModemManagerService, simPath)
+	c.log("Call %s.SendPin([REDACTED])", SimInterface)
+	return obj.Call(SimInterface+".SendPin", 0, pin).Err
+}
+
+// EnablePin enables or disables the PIN lock on the SIM. The pin string is
+// never logged.
+func (c *Client) EnablePin(simPath dbus.ObjectPath, pin string, enabled bool) error {
+	obj := c.conn.Object(ModemManagerService, simPath)
+	c.log("Call %s.EnablePin([REDACTED], %v)", SimInterface, enabled)
+	return obj.Call(SimInterface+".EnablePin", 0, pin, enabled).Err
+}
+
+// GetUnlockRetries reads modem.UnlockRetries (a{uu}), keyed by MMLock*.
+// Missing entries mean "unknown"; callers should treat absent keys
+// conservatively (e.g. as zero remaining attempts).
+func (c *Client) GetUnlockRetries(modemPath dbus.ObjectPath) (map[uint32]uint32, error) {
+	variant, err := c.GetProperty(modemPath, ModemInterface, "UnlockRetries")
+	if err != nil {
+		return nil, err
+	}
+	if retries, ok := variant.Value().(map[uint32]uint32); ok {
+		return retries, nil
+	}
+	return nil, errors.New("invalid UnlockRetries type")
+}
+
+// GetEnabledFacilityLocks reads modem3gpp.EnabledFacilityLocks (u, bitmask of
+// MMModem3gppFacility flags). Returns 0 with no error when the modem doesn't
+// expose the property (rare but possible during early init).
+func (c *Client) GetEnabledFacilityLocks(modemPath dbus.ObjectPath) (uint32, error) {
+	variant, err := c.GetProperty(modemPath, Modem3gppInterface, "EnabledFacilityLocks")
+	if err != nil {
+		return 0, err
+	}
+	if locks, ok := variant.Value().(uint32); ok {
+		return locks, nil
+	}
+	return 0, errors.New("invalid EnabledFacilityLocks type")
+}
+
+// IsWrongPinError reports whether err is a ModemManager IncorrectPassword.
+func IsWrongPinError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if dbusErr, ok := err.(dbus.Error); ok {
+		return dbusErr.Name == ErrIncorrectPassword
+	}
+	return false
+}
+
+// IsPukRequiredError reports whether err indicates the SIM is PUK-locked.
+func IsPukRequiredError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if dbusErr, ok := err.(dbus.Error); ok {
+		return dbusErr.Name == ErrSimPuk || dbusErr.Name == ErrSimPuk2
+	}
+	return false
 }
 
 // SetupLocation configures location services

--- a/internal/mm/types.go
+++ b/internal/mm/types.go
@@ -69,6 +69,19 @@ const (
 	MMModemLocationSourceAgpsMsb      uint32 = 1 << 6
 )
 
+// 3GPP Facility Locks (bitmask in EnabledFacilityLocks)
+const (
+	MMModem3gppFacilityNone           uint32 = 0
+	MMModem3gppFacilitySim            uint32 = 1 << 0
+	MMModem3gppFacilityFixedDialing   uint32 = 1 << 1
+	MMModem3gppFacilityPhSim          uint32 = 1 << 2
+	MMModem3gppFacilityPhFSim         uint32 = 1 << 3
+	MMModem3gppFacilityNetPers        uint32 = 1 << 4
+	MMModem3gppFacilityNetSubPers     uint32 = 1 << 5
+	MMModem3gppFacilityProviderPers   uint32 = 1 << 6
+	MMModem3gppFacilityCorpPers       uint32 = 1 << 7
+)
+
 // SIM Lock Reason
 const (
 	MMLockUnknown   uint32 = 0

--- a/internal/modem/modem.go
+++ b/internal/modem/modem.go
@@ -66,11 +66,15 @@ type State struct {
 	PowerState         string
 	SIMState           string
 	SIMLockStatus      string
+	SIMPath            dbus.ObjectPath // SIM D-Bus object path; "" if no SIM
+	SIMPinLockEnabled  bool            // sim-pin facility enabled in EnabledFacilityLocks
+	UnlockRetriesPin   uint32          // remaining sim-pin attempts; 0 means unknown/exhausted
 	OperatorName       string
 	OperatorCode       string
 	IsRoaming          bool
 	RegistrationFail   string
 	ErrorState         string
+	PinAction          string // outcome of last SIM PIN reconcile (see internal/sim)
 }
 
 // Manager manages modem operations via D-Bus
@@ -182,6 +186,7 @@ func (m *Manager) GetModemInfo(interfaceName string) (*State, error) {
 	if err == nil {
 		if simPath, ok := simVar.Value().(dbus.ObjectPath); ok && string(simPath) != "/" {
 			state.SIMState = SIMStatePresent
+			state.SIMPath = simPath
 
 			// Get IMSI
 			if imsiVar, err := m.client.GetProperty(simPath, "org.freedesktop.ModemManager1.Sim", "Imsi"); err == nil {
@@ -224,6 +229,16 @@ func (m *Manager) GetModemInfo(interfaceName string) (*State, error) {
 				state.SIMState = SIMStateLocked
 			}
 		}
+	}
+
+	// Read PIN-lock facility flag and remaining unlock retries.
+	// Both are best-effort: failures here don't fail the snapshot, but the
+	// PIN reconcile path treats missing values conservatively (won't act).
+	if locks, err := m.client.GetEnabledFacilityLocks(modemPath); err == nil {
+		state.SIMPinLockEnabled = (locks & mm.MMModem3gppFacilitySim) != 0
+	}
+	if retries, err := m.client.GetUnlockRetries(modemPath); err == nil {
+		state.UnlockRetriesPin = retries[mm.MMLockSimPin]
 	}
 
 	// Get signal quality - returns (ub) struct: quality percentage and "recent" flag

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -19,6 +19,7 @@ import (
 	"modem-service/internal/modem"
 	"modem-service/internal/modem/connectivity"
 	redisClient "modem-service/internal/redis"
+	"modem-service/internal/sim"
 	"modem-service/internal/usb"
 )
 
@@ -49,6 +50,8 @@ type Service struct {
 	Location              *location.Service
 	Modem                 *modem.Manager
 	MMClient              *mm.Client
+	Sim                   *sim.Manager
+	simPin                atomic.Value // string; PIN configured via cellular.sim-pin setting
 	LastState             *modem.State
 	WaitingForGPSLogged   bool       // Tracks if we've already logged the waiting for GPS message
 	GPSEnabledTime        time.Time  // When GPS was first enabled
@@ -136,6 +139,7 @@ func New(cfg *config.Config, logger *log.Logger, version string) (*Service, erro
 		Health:              health.New(),
 		Modem:               modemMgr,
 		MMClient:            mmClient,
+		Sim:                 sim.New(mmClient, logger),
 		Location:            location.NewService(logger, cfg.GpsdServer, mmClient, cfg.SuplServer),
 		LastState:           modem.NewState(),
 		WaitingForGPSLogged: false,
@@ -148,6 +152,7 @@ func New(cfg *config.Config, logger *log.Logger, version string) (*Service, erro
 	service.gpsEnabled.Store(true)           // default: GPS on
 	service.cellLocationEnabled.Store(false) // default: cell location off
 	service.modemEnabled.Store(true)         // default: modem on until pm-service says otherwise
+	service.simPin.Store("")                 // default: no PIN configured
 
 	cell.SetVersion(version)
 	service.Logger.Printf("modem-service %s", version)
@@ -185,6 +190,17 @@ func (s *Service) Run(ctx context.Context) error {
 		enabled := value == "true"
 		s.cellLocationEnabled.Store(enabled)
 		s.Logger.Printf("Cell location %s", map[bool]string{true: "enabled", false: "disabled"}[enabled])
+		return nil
+	})
+	// SIM PIN setting. The value is sensitive — never logged. The next monitor
+	// tick reads simPin via Load() and feeds it to sim.Manager.Reconcile.
+	s.Redis.StartSettingsWatcher("cellular.sim-pin", func(value string) error {
+		s.simPin.Store(value)
+		if value == "" {
+			s.Logger.Printf("SIM PIN cleared")
+		} else {
+			s.Logger.Printf("SIM PIN configured")
+		}
 		return nil
 	})
 	s.Redis.StartSettingsWatching()
@@ -807,6 +823,14 @@ func (s *Service) publishModemState(ctx context.Context, currentState *modem.Sta
 		s.LastState.SIMLockStatus = currentState.SIMLockStatus
 	}
 
+	if s.LastState.PinAction != currentState.PinAction {
+		if err := s.Redis.PublishModemState("pin-action", currentState.PinAction); err != nil {
+			return err
+		}
+		modemChanges = append(modemChanges, fmt.Sprintf("pin-action=%s", currentState.PinAction))
+		s.LastState.PinAction = currentState.PinAction
+	}
+
 	if s.LastState.OperatorName != currentState.OperatorName {
 		if err := s.Redis.PublishModemState("operator-name", currentState.OperatorName); err != nil {
 			return err
@@ -966,6 +990,18 @@ func (s *Service) checkAndPublishModemStatus(ctx context.Context) error {
 		s.publishHealthState(ctx)
 		return err // Return the original error from GetModemInfo
 	}
+
+	// Reconcile SIM PIN state with the configured cellular.sim-pin setting.
+	// The manager owns retry-counter gating so the service can never push the
+	// SIM into PUK lock by itself.
+	pin, _ := s.simPin.Load().(string)
+	currentState.PinAction = string(s.Sim.Reconcile(sim.Input{
+		SIMPath:           currentState.SIMPath,
+		LockStatus:        currentState.SIMLockStatus,
+		SIMPinLockEnabled: currentState.SIMPinLockEnabled,
+		UnlockRetriesPin:  currentState.UnlockRetriesPin,
+		ConfiguredPIN:     pin,
+	}))
 
 	internetStatus := "disconnected"
 	if currentState.Status == "connected" {

--- a/internal/sim/manager.go
+++ b/internal/sim/manager.go
@@ -1,0 +1,177 @@
+// Package sim reconciles SIM PIN state with the configured cellular.sim-pin
+// setting. It owns the decision of whether to send the PIN (when the SIM is
+// PIN-locked) or enable PIN-lock (when it's currently disabled). Wrong-PIN
+// attempts are gated by the modem's UnlockRetries counter so the service
+// can never push a SIM into PUK state on its own — see the design doc at
+// docs/superpowers/specs/2026-05-05-sim-pin-support-design.md.
+package sim
+
+import (
+	"log"
+	"sync"
+
+	"github.com/godbus/dbus/v5"
+
+	"modem-service/internal/mm"
+)
+
+// Outcome describes the result of one Reconcile call. It's published verbatim
+// to the modem.pin-action Redis field.
+type Outcome string
+
+const (
+	OutcomeUnconfigured   Outcome = "unconfigured"
+	OutcomeOK             Outcome = "ok"
+	OutcomeUnlocked       Outcome = "unlocked"
+	OutcomeLockEnabled    Outcome = "lock-enabled"
+	OutcomeWrongPin       Outcome = "wrong-pin"
+	OutcomeLowRetriesBail Outcome = "low-retries-bail"
+	OutcomePukRequired    Outcome = "puk-required"
+	OutcomeError          Outcome = "error"
+)
+
+// minRetriesBeforeAttempt is the SIM-PIN retry count required for the manager
+// to attempt a SendPin or EnablePin. Three is the standard maximum on a fresh
+// SIM, so requiring "== max" means we only ever consume one retry: if our
+// guess is wrong, we stop and let a human recover by sending the correct PIN
+// manually (which restores the counter to 3).
+const minRetriesBeforeAttempt = 3
+
+// SimDBus is the narrow D-Bus surface the manager needs. The mm.Client
+// satisfies this interface; tests substitute a recorder.
+type SimDBus interface {
+	SendPin(simPath dbus.ObjectPath, pin string) error
+	EnablePin(simPath dbus.ObjectPath, pin string, enabled bool) error
+}
+
+// Input is the per-cycle snapshot passed to Reconcile. All fields come from
+// modem.State and the cached settings hash; Reconcile does no I/O of its own
+// beyond the SimDBus calls.
+type Input struct {
+	SIMPath           dbus.ObjectPath
+	LockStatus        string // "" if unlocked, otherwise mm.LockReasonToString
+	SIMPinLockEnabled bool
+	UnlockRetriesPin  uint32
+	ConfiguredPIN     string
+}
+
+// Manager keeps a single boolean of "did we already try and fail this run?"
+// across cycles. State is process-local; a restart resets it but the
+// retry-count gate still protects the SIM.
+type Manager struct {
+	dbus   SimDBus
+	logger *log.Logger
+
+	mu           sync.Mutex
+	triedThisRun bool
+}
+
+// New returns a Manager bound to the given D-Bus surface and logger.
+func New(d SimDBus, logger *log.Logger) *Manager {
+	if logger == nil {
+		logger = log.Default()
+	}
+	return &Manager{dbus: d, logger: logger}
+}
+
+// Reconcile runs the decision matrix described in the design doc and returns
+// the outcome for publication. It may make at most one D-Bus call per
+// invocation.
+func (m *Manager) Reconcile(in Input) Outcome {
+	if in.ConfiguredPIN == "" {
+		return OutcomeUnconfigured
+	}
+
+	switch in.LockStatus {
+	case "sim-puk", "sim-puk2":
+		return OutcomePukRequired
+	case "sim-pin2":
+		// PIN2 doesn't block data. Whatever sim-pin's enabled state is, we
+		// don't touch it via PIN2 path.
+		return OutcomeOK
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	switch in.LockStatus {
+	case "sim-pin":
+		return m.actUnlock(in)
+	case "":
+		// Unlocked. Enable lock if it isn't already.
+		if in.SIMPinLockEnabled {
+			return OutcomeOK
+		}
+		return m.actEnableLock(in)
+	default:
+		// Other lock reasons (ph-sim-pin etc.) — out of scope.
+		m.logger.Printf("sim: unhandled lock status %q, no action", in.LockStatus)
+		return OutcomeOK
+	}
+}
+
+func (m *Manager) actUnlock(in Input) Outcome {
+	if in.SIMPath == "" {
+		m.logger.Printf("sim: cannot unlock — SIM D-Bus path is empty")
+		return OutcomeError
+	}
+	if m.triedThisRun {
+		return OutcomeWrongPin
+	}
+	if in.UnlockRetriesPin < minRetriesBeforeAttempt {
+		m.logger.Printf("sim: refusing to send PIN (retries=%d < %d) to avoid PUK lock",
+			in.UnlockRetriesPin, minRetriesBeforeAttempt)
+		return OutcomeLowRetriesBail
+	}
+
+	err := m.dbus.SendPin(in.SIMPath, in.ConfiguredPIN)
+	if err == nil {
+		m.logger.Printf("sim: SendPin succeeded, SIM unlocked")
+		return OutcomeUnlocked
+	}
+	if mm.IsPukRequiredError(err) {
+		m.logger.Printf("sim: SendPin returned PUK required: %v", err)
+		return OutcomePukRequired
+	}
+	if mm.IsWrongPinError(err) {
+		m.triedThisRun = true
+		m.logger.Printf("sim: SendPin rejected (wrong PIN); will not retry until restart and retries are restored to %d",
+			minRetriesBeforeAttempt)
+		return OutcomeWrongPin
+	}
+	m.logger.Printf("sim: SendPin failed: %v", err)
+	return OutcomeError
+}
+
+func (m *Manager) actEnableLock(in Input) Outcome {
+	if in.SIMPath == "" {
+		m.logger.Printf("sim: cannot enable PIN lock — SIM D-Bus path is empty")
+		return OutcomeError
+	}
+	if m.triedThisRun {
+		return OutcomeWrongPin
+	}
+	if in.UnlockRetriesPin < minRetriesBeforeAttempt {
+		m.logger.Printf("sim: refusing to enable PIN lock (retries=%d < %d) to avoid PUK lock",
+			in.UnlockRetriesPin, minRetriesBeforeAttempt)
+		return OutcomeLowRetriesBail
+	}
+
+	err := m.dbus.EnablePin(in.SIMPath, in.ConfiguredPIN, true)
+	if err == nil {
+		m.logger.Printf("sim: EnablePin(true) succeeded, PIN lock now enabled")
+		return OutcomeLockEnabled
+	}
+	if mm.IsPukRequiredError(err) {
+		m.logger.Printf("sim: EnablePin returned PUK required: %v", err)
+		return OutcomePukRequired
+	}
+	if mm.IsWrongPinError(err) {
+		m.triedThisRun = true
+		m.logger.Printf("sim: EnablePin rejected (wrong PIN); will not retry until restart and retries are restored to %d",
+			minRetriesBeforeAttempt)
+		return OutcomeWrongPin
+	}
+	m.logger.Printf("sim: EnablePin failed: %v", err)
+	return OutcomeError
+}

--- a/internal/sim/manager_test.go
+++ b/internal/sim/manager_test.go
@@ -1,0 +1,365 @@
+package sim
+
+import (
+	"errors"
+	"io"
+	"log"
+	"testing"
+
+	"github.com/godbus/dbus/v5"
+
+	"modem-service/internal/mm"
+)
+
+const testSimPath dbus.ObjectPath = "/org/freedesktop/ModemManager1/SIM/0"
+
+// fakeDBus records calls and returns canned errors.
+type fakeDBus struct {
+	sendPinErr   error
+	enablePinErr error
+
+	sendPinCalls   int
+	enablePinCalls int
+	lastEnabled    bool
+}
+
+func (f *fakeDBus) SendPin(_ dbus.ObjectPath, _ string) error {
+	f.sendPinCalls++
+	return f.sendPinErr
+}
+
+func (f *fakeDBus) EnablePin(_ dbus.ObjectPath, _ string, enabled bool) error {
+	f.enablePinCalls++
+	f.lastEnabled = enabled
+	return f.enablePinErr
+}
+
+func newManager(d *fakeDBus) *Manager {
+	return &Manager{
+		dbus:   d,
+		logger: log.New(io.Discard, "", 0),
+	}
+}
+
+func wrongPinErr() error {
+	return dbus.Error{Name: mm.ErrIncorrectPassword}
+}
+
+func pukErr() error {
+	return dbus.Error{Name: mm.ErrSimPuk}
+}
+
+// --- Configured PIN empty ----------------------------------------------------
+
+func TestReconcile_NoPinConfigured(t *testing.T) {
+	d := &fakeDBus{}
+	m := newManager(d)
+
+	out := m.Reconcile(Input{
+		SIMPath:          testSimPath,
+		LockStatus:       "sim-pin",
+		UnlockRetriesPin: 3,
+		ConfiguredPIN:    "",
+	})
+
+	if out != OutcomeUnconfigured {
+		t.Fatalf("got %q, want %q", out, OutcomeUnconfigured)
+	}
+	if d.sendPinCalls != 0 || d.enablePinCalls != 0 {
+		t.Fatalf("must not call D-Bus when PIN is unconfigured: send=%d enable=%d",
+			d.sendPinCalls, d.enablePinCalls)
+	}
+}
+
+// --- Locked → SendPin --------------------------------------------------------
+
+func TestReconcile_LockedSendsPinWhenRetriesFull(t *testing.T) {
+	d := &fakeDBus{}
+	m := newManager(d)
+
+	out := m.Reconcile(Input{
+		SIMPath:          testSimPath,
+		LockStatus:       "sim-pin",
+		UnlockRetriesPin: 3,
+		ConfiguredPIN:    "0000",
+	})
+
+	if out != OutcomeUnlocked {
+		t.Fatalf("got %q, want %q", out, OutcomeUnlocked)
+	}
+	if d.sendPinCalls != 1 {
+		t.Fatalf("expected 1 SendPin call, got %d", d.sendPinCalls)
+	}
+}
+
+func TestReconcile_LockedWrongPinTriedOnce(t *testing.T) {
+	d := &fakeDBus{sendPinErr: wrongPinErr()}
+	m := newManager(d)
+
+	in := Input{
+		SIMPath:          testSimPath,
+		LockStatus:       "sim-pin",
+		UnlockRetriesPin: 3,
+		ConfiguredPIN:    "0000",
+	}
+
+	out := m.Reconcile(in)
+	if out != OutcomeWrongPin {
+		t.Fatalf("first call: got %q, want %q", out, OutcomeWrongPin)
+	}
+	if d.sendPinCalls != 1 {
+		t.Fatalf("first call: expected 1 SendPin, got %d", d.sendPinCalls)
+	}
+
+	// Second cycle: triedThisRun must short-circuit, no further D-Bus call.
+	in.UnlockRetriesPin = 2
+	out = m.Reconcile(in)
+	if out != OutcomeWrongPin {
+		t.Fatalf("second call: got %q, want %q", out, OutcomeWrongPin)
+	}
+	if d.sendPinCalls != 1 {
+		t.Fatalf("second call: expected still 1 SendPin, got %d", d.sendPinCalls)
+	}
+}
+
+func TestReconcile_LockedRefusesWhenRetriesLow(t *testing.T) {
+	d := &fakeDBus{}
+	m := newManager(d)
+
+	out := m.Reconcile(Input{
+		SIMPath:          testSimPath,
+		LockStatus:       "sim-pin",
+		UnlockRetriesPin: 2,
+		ConfiguredPIN:    "0000",
+	})
+
+	if out != OutcomeLowRetriesBail {
+		t.Fatalf("got %q, want %q", out, OutcomeLowRetriesBail)
+	}
+	if d.sendPinCalls != 0 {
+		t.Fatalf("must not call SendPin when retries < 3: %d", d.sendPinCalls)
+	}
+}
+
+func TestReconcile_LockedRefusesWhenRetriesUnknown(t *testing.T) {
+	d := &fakeDBus{}
+	m := newManager(d)
+
+	out := m.Reconcile(Input{
+		SIMPath:          testSimPath,
+		LockStatus:       "sim-pin",
+		UnlockRetriesPin: 0,
+		ConfiguredPIN:    "0000",
+	})
+
+	if out != OutcomeLowRetriesBail {
+		t.Fatalf("got %q, want %q", out, OutcomeLowRetriesBail)
+	}
+	if d.sendPinCalls != 0 {
+		t.Fatalf("must not call SendPin when retries unknown: %d", d.sendPinCalls)
+	}
+}
+
+func TestReconcile_LockedDBusErrorReturnsError(t *testing.T) {
+	d := &fakeDBus{sendPinErr: errors.New("bus blew up")}
+	m := newManager(d)
+
+	out := m.Reconcile(Input{
+		SIMPath:          testSimPath,
+		LockStatus:       "sim-pin",
+		UnlockRetriesPin: 3,
+		ConfiguredPIN:    "0000",
+	})
+
+	if out != OutcomeError {
+		t.Fatalf("got %q, want %q", out, OutcomeError)
+	}
+	// triedThisRun must NOT be set on a non-bad-pin error: that error
+	// didn't necessarily consume a retry, and we want a chance on the
+	// next cycle if the bus recovers.
+	out = m.Reconcile(Input{
+		SIMPath:          testSimPath,
+		LockStatus:       "sim-pin",
+		UnlockRetriesPin: 3,
+		ConfiguredPIN:    "0000",
+	})
+	if d.sendPinCalls != 2 {
+		t.Fatalf("non-IncorrectPassword error must not flip triedThisRun, got %d calls", d.sendPinCalls)
+	}
+	_ = out
+}
+
+// --- PIN2 / PUK / unknown locks ---------------------------------------------
+
+func TestReconcile_LockedPin2IsHarmless(t *testing.T) {
+	d := &fakeDBus{}
+	m := newManager(d)
+
+	out := m.Reconcile(Input{
+		SIMPath:           testSimPath,
+		LockStatus:        "sim-pin2",
+		SIMPinLockEnabled: true,
+		UnlockRetriesPin:  3,
+		ConfiguredPIN:     "0000",
+	})
+
+	if out != OutcomeOK {
+		t.Fatalf("pin2 with sim-pin enabled: got %q, want %q", out, OutcomeOK)
+	}
+	if d.sendPinCalls != 0 || d.enablePinCalls != 0 {
+		t.Fatalf("pin2 must not trigger any D-Bus call")
+	}
+}
+
+func TestReconcile_LockedPukRequired(t *testing.T) {
+	d := &fakeDBus{}
+	m := newManager(d)
+
+	for _, lock := range []string{"sim-puk", "sim-puk2"} {
+		out := m.Reconcile(Input{
+			SIMPath:          testSimPath,
+			LockStatus:       lock,
+			UnlockRetriesPin: 3,
+			ConfiguredPIN:    "0000",
+		})
+		if out != OutcomePukRequired {
+			t.Fatalf("%s: got %q, want %q", lock, out, OutcomePukRequired)
+		}
+	}
+	if d.sendPinCalls != 0 || d.enablePinCalls != 0 {
+		t.Fatalf("PUK lock must not trigger any D-Bus call")
+	}
+}
+
+// --- Unlocked: enable lock ---------------------------------------------------
+
+func TestReconcile_UnlockedEnablesLockWhenDisabled(t *testing.T) {
+	d := &fakeDBus{}
+	m := newManager(d)
+
+	out := m.Reconcile(Input{
+		SIMPath:           testSimPath,
+		LockStatus:        "",
+		SIMPinLockEnabled: false,
+		UnlockRetriesPin:  3,
+		ConfiguredPIN:     "0000",
+	})
+
+	if out != OutcomeLockEnabled {
+		t.Fatalf("got %q, want %q", out, OutcomeLockEnabled)
+	}
+	if d.enablePinCalls != 1 || d.lastEnabled != true {
+		t.Fatalf("expected 1 EnablePin(true), got calls=%d enabled=%v",
+			d.enablePinCalls, d.lastEnabled)
+	}
+}
+
+func TestReconcile_UnlockedNoOpWhenLockAlreadyEnabled(t *testing.T) {
+	d := &fakeDBus{}
+	m := newManager(d)
+
+	out := m.Reconcile(Input{
+		SIMPath:           testSimPath,
+		LockStatus:        "",
+		SIMPinLockEnabled: true,
+		UnlockRetriesPin:  3,
+		ConfiguredPIN:     "0000",
+	})
+
+	if out != OutcomeOK {
+		t.Fatalf("got %q, want %q", out, OutcomeOK)
+	}
+	if d.sendPinCalls != 0 || d.enablePinCalls != 0 {
+		t.Fatalf("must not touch D-Bus when already in desired state")
+	}
+}
+
+func TestReconcile_UnlockedWrongPinOnEnableTriedOnce(t *testing.T) {
+	d := &fakeDBus{enablePinErr: wrongPinErr()}
+	m := newManager(d)
+
+	in := Input{
+		SIMPath:           testSimPath,
+		LockStatus:        "",
+		SIMPinLockEnabled: false,
+		UnlockRetriesPin:  3,
+		ConfiguredPIN:     "0000",
+	}
+
+	out := m.Reconcile(in)
+	if out != OutcomeWrongPin {
+		t.Fatalf("first: got %q, want %q", out, OutcomeWrongPin)
+	}
+
+	// Second cycle: same input, must not retry.
+	in.UnlockRetriesPin = 2
+	out = m.Reconcile(in)
+	if out != OutcomeWrongPin {
+		t.Fatalf("second: got %q, want %q", out, OutcomeWrongPin)
+	}
+	if d.enablePinCalls != 1 {
+		t.Fatalf("expected 1 EnablePin call across two cycles, got %d", d.enablePinCalls)
+	}
+}
+
+func TestReconcile_UnlockedRefusesEnableWhenRetriesLow(t *testing.T) {
+	d := &fakeDBus{}
+	m := newManager(d)
+
+	out := m.Reconcile(Input{
+		SIMPath:           testSimPath,
+		LockStatus:        "",
+		SIMPinLockEnabled: false,
+		UnlockRetriesPin:  2,
+		ConfiguredPIN:     "0000",
+	})
+
+	if out != OutcomeLowRetriesBail {
+		t.Fatalf("got %q, want %q", out, OutcomeLowRetriesBail)
+	}
+	if d.enablePinCalls != 0 {
+		t.Fatalf("must not call EnablePin when retries < 3")
+	}
+}
+
+// --- Cross-state safety -----------------------------------------------------
+
+func TestReconcile_NoSimPath(t *testing.T) {
+	d := &fakeDBus{}
+	m := newManager(d)
+
+	out := m.Reconcile(Input{
+		SIMPath:          "",
+		LockStatus:       "sim-pin",
+		UnlockRetriesPin: 3,
+		ConfiguredPIN:    "0000",
+	})
+
+	// Without a SIM path we cannot call SendPin/EnablePin. Treat as error
+	// so the operator sees something is off; do not flip triedThisRun.
+	if out != OutcomeError {
+		t.Fatalf("got %q, want %q", out, OutcomeError)
+	}
+	if d.sendPinCalls != 0 || d.enablePinCalls != 0 {
+		t.Fatalf("must not call D-Bus without a SIM path")
+	}
+}
+
+func TestReconcile_PukErrorFromBadPinAttempt(t *testing.T) {
+	// EnablePin/SendPin can return SimPuk if the SIM was already PUK-locked
+	// when the call landed (race against external mmcli). Treat as PUK,
+	// not as a counted retry.
+	d := &fakeDBus{sendPinErr: pukErr()}
+	m := newManager(d)
+
+	out := m.Reconcile(Input{
+		SIMPath:          testSimPath,
+		LockStatus:       "sim-pin",
+		UnlockRetriesPin: 3,
+		ConfiguredPIN:    "0000",
+	})
+
+	if out != OutcomePukRequired {
+		t.Fatalf("got %q, want %q", out, OutcomePukRequired)
+	}
+}


### PR DESCRIPTION
## Summary

Adds support for PIN-locked SIMs. When the new `cellular.sim-pin` setting is set:

- if the SIM is PIN-locked, modem-service sends the PIN to unlock it;
- if the SIM has PIN lock disabled, modem-service enables it with the configured PIN.

Either action implicitly verifies the PIN, since `SendPin` / `EnablePin` reject a wrong PIN at the SIM hardware level.

## Safety policy

Wrong-PIN attempts are gated by the modem's `UnlockRetries` counter to prevent the service from ever pushing the SIM into PUK state on its own:

- only attempt when `unlock-retries["sim-pin"]` is at the maximum (3);
- after one failed attempt this run, refuse further attempts;
- to recover from a misconfigured PIN, fix the setting and `mmcli --send-pin=CORRECT` once manually — that restores the retry counter, and modem-service resumes normally.

PIN2 / PUK / `ph-sim-pin` etc. are explicitly out of scope (documented in the design doc).

## Outcome reporting

Each reconcile cycle's outcome is published to a new `modem.pin-action` Redis field: `unconfigured`, `ok`, `unlocked`, `lock-enabled`, `wrong-pin`, `low-retries-bail`, `puk-required`, or `error`. README updated.

## Files

- `internal/sim/` — new package with `Manager.Reconcile` (decision matrix, retry gating, triedThisRun tracking) and 14 table-driven tests
- `internal/mm/client.go` — `SendPin`, `EnablePin`, `GetUnlockRetries`, `GetEnabledFacilityLocks`, `IsWrongPinError`, `IsPukRequiredError`
- `internal/mm/types.go` — `MMModem3gppFacility*` constants
- `internal/modem/modem.go` — `State` extended with `SIMPath`, `SIMPinLockEnabled`, `UnlockRetriesPin`, `PinAction`; populated in `GetModemInfo`
- `internal/service/service.go` — registers the `cellular.sim-pin` settings watcher, calls `Sim.Reconcile` after `GetModemInfo`, publishes `pin-action` change detection
- `README.md` — documents `pin-action` field and recovery flow
- `docs/superpowers/specs/2026-05-05-sim-pin-support-design.md` — design doc

Bean: librescoot-t0jf

Companion PR: librescoot/settings-service adds the `cellular.sim-pin` schema entry.

## Test plan

- [x] Unit tests for the decision matrix (`internal/sim/manager_test.go`, 14 cases)
- [x] `go vet ./...` clean
- [x] ARM cross-compile clean (`make build`)
- [ ] Deep-Blue manual: deploy, configure `cellular.sim-pin`, lock the SIM via `mmcli --enable-pin`, restart modem-service, verify automatic unlock
- [ ] Deep-Blue manual: deploy, configure wrong PIN, verify `pin-action=wrong-pin` and that subsequent restarts publish `low-retries-bail` (retries=2) without further attempts