### PR TITLE
fix(redis): don't log values from settings watcher

### DIFF
--- a/internal/redis/redis.go
+++ b/internal/redis/redis.go
@@ -178,7 +178,9 @@ func (c *Client) StartSettingsWatcher(field string, handler SettingHandler) {
 		c.settingsWatch = c.client.NewHashWatcher("settings")
 	}
 	c.settingsWatch.OnField(field, func(value string) error {
-		c.logger.Printf("Setting %s changed: %s", field, value)
+		// Don't log the value here: some settings (e.g. cellular.sim-pin) are
+		// sensitive. Per-field handlers can log a redacted summary themselves.
+		c.logger.Printf("Setting %s changed", field)
 		return handler(value)
 	})
 }


### PR DESCRIPTION
## Summary

`StartSettingsWatcher` in `internal/redis/redis.go` logged every settings field change as `Setting X changed: Y`. That printed sensitive values verbatim to the journal — confirmed during testing of the new `cellular.sim-pin` handler in #11, where `9011` ended up in `journalctl -u librescoot-modem`.

The fix removes the value from the generic log line. Per-field handlers can still log a redacted summary themselves (the `cellular.sim-pin` handler already does: `SIM PIN configured` / `SIM PIN cleared`).

## Test plan

- [x] Built and deployed to deep-blue, restarted librescoot-modem with `cellular.sim-pin=9011` in settings
- [x] Verified journal now shows `Setting cellular.sim-pin changed` (no value) followed by `SIM PIN configured`
- [x] `pin-action=ok` still published correctly (SIM in `sim-pin2` state, reconcile correctly no-ops)